### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/neopilot-ai/native/security/code-scanning/1](https://github.com/neopilot-ai/native/security/code-scanning/1)

The best way to fix the problem is to add an explicit `permissions` block near the top of the workflow, either at the root (applies to all jobs unless overridden by a job-level block) or, if more granular control is needed, directly under the specific job that needs it. As a minimal fix, adding `permissions: contents: read` at the workflow root just after the `name` and before `on` ensures that only read access to repository contents is granted by default. If any steps later fail due to insufficient permissions (e.g., while uploading artifacts), job- or step-level blocks can be used to selectively grant more permissions. To implement this change, edit `.github/workflows/ci.yml` and insert the following block:

```yaml
permissions:
  contents: read
```

immediately after the `name: CI` line, before the `on:` block.

No new imports, methods, or definitions are required. This is a pure YAML change.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
